### PR TITLE
Fix prompt multiline output delimiter

### DIFF
--- a/.github/workflows/reuse-ai-orchestrator.yml
+++ b/.github/workflows/reuse-ai-orchestrator.yml
@@ -158,9 +158,7 @@ jobs:
 
           # Expose prompt as a multiline output (so OpenCode action receives the prompt text, not a file path)
           {
-            echo "prompt<<'EO_PROMPT'"
             cat "$PROMPT_PATH"
-            echo "$DELIM"
           } >> "$GITHUB_OUTPUT"
       - name: Check existing PR for issue (skip if present)
         id: existing_pr


### PR DESCRIPTION
Fixes broken GITHUB_OUTPUT multiline delimiter (DELIM undefined + mismatched delimiter) so OpenCode receives prompt reliably.