### PR TITLE
Fix prompt multiline GITHUB_OUTPUT delimiter

### DIFF
--- a/.github/workflows/reuse-ai-orchestrator.yml
+++ b/.github/workflows/reuse-ai-orchestrator.yml
@@ -157,10 +157,11 @@ jobs:
           } >> "$PROMPT_PATH"
 
           # Expose prompt as a multiline output (so OpenCode action receives the prompt text, not a file path)
+          DELIM="EO_PROMPT_${GITHUB_RUN_ID}_${RANDOM}"
           {
-            echo "prompt<<'EO_PROMPT'"
+            printf 'prompt<<%s\n' "$DELIM"
             cat "$PROMPT_PATH"
-            echo "$DELIM"
+            printf '%s\n' "$DELIM"
           } >> "$GITHUB_OUTPUT"
       - name: Check existing PR for issue (skip if present)
         id: existing_pr


### PR DESCRIPTION
Fixes DELIM unbound + invalid delimiter quoting. Ensures prompt output follows GitHub multiline output syntax.