### PR TITLE
fix: make gh repo explicit in reusable triage/watchdog

### DIFF
--- a/.github/workflows/reuse-ai-triage.yml
+++ b/.github/workflows/reuse-ai-triage.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
-          gh run view "$RUN_ID" --log-failed > FAILED.log || true
+          gh run view --repo "$GITHUB_REPOSITORY" "$RUN_ID" --log-failed > FAILED.log || true
           head -c 12000 FAILED.log > FAILED_TRUNC.log || true
           echo "log=FAILED_TRUNC.log" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/reuse-ai-watchdog.yml
+++ b/.github/workflows/reuse-ai-watchdog.yml
@@ -20,7 +20,7 @@ jobs:
           echo "Recent CI failures (sample window) = $FAILS"
 
           if [ "$FAILS" -ge 3 ]; then
-            gh issue create \
+            gh issue create --repo "$GITHUB_REPOSITORY" \
               --title "AI Watchdog: PAUSE recommended (failures=$FAILS)" \
               --body "Detected frequent CI failures. Recommend setting AI_AUTOMATION_MODE=PAUSE and running triage." \
               --label "ai:triage"


### PR DESCRIPTION
Reusable workflows do not checkout the repo, so gh cannot infer target repo. Add --repo "$GITHUB_REPOSITORY" to gh commands to avoid base-repo detection failures.