### PR TITLE
fix(workflows): harden watchdog/daily repo context + triage inputs

### DIFF
--- a/.github/workflows/reuse-ai-daily.yml
+++ b/.github/workflows/reuse-ai-daily.yml
@@ -15,9 +15,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # JP: ここでは簡易集計 / EN: simple counters
-          OPEN_READY=$(gh issue list --state open --label "ai:ready" --json number --jq 'length')
-          OPEN_BLOCKED=$(gh issue list --state open --label "ai:blocked" --json number --jq 'length')
-          OPEN_AI_PRS=$(gh pr list --state open --label "ai:in-progress" --json number --jq 'length')
+          OPEN_READY=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "ai:ready" --json number --jq 'length')
+          OPEN_BLOCKED=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "ai:blocked" --json number --jq 'length')
+          OPEN_AI_PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --label "ai:in-progress" --json number --jq 'length')
 
           BODY=$(cat << EOF
           ## Daily AI Report (UTC) - $(date -u +"%Y-%m-%d")
@@ -33,9 +33,9 @@ jobs:
           )
 
           # JP: 固定Issueが無い場合は作る / EN: create if missing
-          DASH_ID=$(gh issue list --state open --search "AI Ops Dashboard" --json number --jq '.[0].number // empty')
+          DASH_ID=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "AI Ops Dashboard" --json number --jq '.[0].number // empty')
           if [ -z "$DASH_ID" ]; then
-            DASH_ID=$(gh issue create --title "AI Ops Dashboard" --body "Daily reports will be posted here." --label "ai:triage" --json number --jq '.number')
+            DASH_ID=$(gh issue create --repo "$GITHUB_REPOSITORY" --title "AI Ops Dashboard" --body "Daily reports will be posted here." --label "ai:triage" --json number --jq '.number')
           fi
 
-          gh issue comment "$DASH_ID" --body "$BODY"
+          gh issue comment --repo "$GITHUB_REPOSITORY" "$DASH_ID" --body "$BODY"

--- a/.github/workflows/reuse-ai-triage.yml
+++ b/.github/workflows/reuse-ai-triage.yml
@@ -6,6 +6,12 @@ on:
       model:
         type: string
         required: true
+      failing_run_id:
+        type: string
+        required: false
+      failing_run_url:
+        type: string
+        required: false
     secrets:
       ZAI_API_KEY:
         required: true
@@ -31,16 +37,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # workflow_run で来た場合
-          RUN_ID="${{ github.event.workflow_run.id }}"
+          # Prefer workflow_call inputs (from dispatcher -> workflow_dispatch) and keep workflow_run fallback
+          RUN_ID="${{ inputs.failing_run_id }}"
+          RUN_URL="${{ inputs.failing_run_url }}"
           if [ -z "$RUN_ID" ]; then
-            echo "Not a workflow_run event. Exiting."
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            RUN_URL="${{ github.event.workflow_run.html_url }}"
+          fi
+
+          if [ -z "$RUN_ID" ]; then
+            echo "No failing run id (inputs.failing_run_id / workflow_run.id). Exiting."
             exit 0
           fi
 
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
-          gh run view --repo "$GITHUB_REPOSITORY" "$RUN_ID" --log-failed > FAILED.log || true
-          head -c 12000 FAILED.log > FAILED_TRUNC.log || true
+          echo "run_url=$RUN_URL" >> $GITHUB_OUTPUT
+          gh run view --repo "$GITHUB_REPOSITORY" "$RUN_ID" --log-failed > FAILED.log || true          head -c 12000 FAILED.log > FAILED_TRUNC.log || true
           echo "log=FAILED_TRUNC.log" >> $GITHUB_OUTPUT
 
       - name: Build triage prompt

--- a/.github/workflows/reuse-ai-watchdog.yml
+++ b/.github/workflows/reuse-ai-watchdog.yml
@@ -15,7 +15,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # JP: 直近のCI失敗回数（例） / EN: count recent CI failures
-          FAILS=$(gh run list --workflow "CI" --limit 50 --json conclusion,createdAt \
+          FAILS=$(gh run list -R "$GITHUB_REPOSITORY" --workflow "CI" --limit 50 --json conclusion,createdAt \
             --jq '[.[] | select(.conclusion=="failure")] | length')
           echo "Recent CI failures (sample window) = $FAILS"
 


### PR DESCRIPTION
EN:
- Add explicit repo context (GITHUB_REPOSITORY) to gh commands in watchdog/daily.
- Make triage reusable accept failing_run_id via inputs (dispatcher -> workflow_dispatch), keep workflow_run fallback.

JP:
- watchdog/daily の gh コマンドに明示的な repo 指定を追加（checkout無しでも安定）。
- triage reusable に failing_run_id inputs を追加し、dispatcher経由でも解析できるように（workflow_run互換維持）。
Rollback: git revert this commit.