### PR TITLE
Align CI/validate naming with required status context

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate YAML (workflows/actions)
+        run: |
+          ruby -ryaml -e '
+            files = Dir.glob(".github/**/*.{yml,yaml}").select { |f| File.file?(f) }
+            files.each { |f| YAML.load_file(f) }
+            puts "YAML OK: #{files.length} files"
+          '
+
+      - name: Parse PowerShell scripts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $files = Get-ChildItem -Recurse -File -Filter *.ps1
+          foreach($f in $files){
+            $tokens=$null; $errors=$null
+            [void][System.Management.Automation.Language.Parser]::ParseFile($f.FullName,[ref]$tokens,[ref]$errors)
+            if($errors -and @($errors).Count -gt 0){
+              throw ("Parse failed: {0}`n{1}" -f $f.FullName, ($errors | Out-String))
+            }
+          }
+          Write-Host ("PS Parse OK: {0} files" -f $files.Count)
+


### PR DESCRIPTION
Stabilize workflow/job display names to match required check context (CI/validate) and avoid 'Expected' waiting.